### PR TITLE
Add achievement badges

### DIFF
--- a/src/components/AchievementBadge.tsx
+++ b/src/components/AchievementBadge.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+export interface AchievementBadgeProps {
+  /** Total points accumulated across all tasks */
+  totalPoints: number;
+  /** Number of consecutive days with at least one task */
+  streak: number;
+}
+
+/**
+ * Determine which badge label to show based on the total points earned.
+ * Returns null if no badge threshold has been reached.
+ */
+function getBadgeLabel(points: number): string | null {
+  if (points >= 500) return 'Gold';
+  if (points >= 200) return 'Silver';
+  if (points >= 100) return 'Bronze';
+  return null;
+}
+
+/**
+ * AchievementBadge shows a small visual indicator of a user's progress
+ * in the form of a badge for point milestones and a streak counter.
+ */
+const AchievementBadge: React.FC<AchievementBadgeProps> = ({ totalPoints, streak }) => {
+  const badge = getBadgeLabel(totalPoints);
+  return (
+    <div className="flex space-x-2 mt-2">
+      {badge && (
+        <span className="bg-yellow-200 text-yellow-800 text-xs font-semibold px-2 py-1 rounded-full">
+          {badge} Badge
+        </span>
+      )}
+      {streak > 1 && (
+        <span className="bg-orange-200 text-orange-800 text-xs font-semibold px-2 py-1 rounded-full">
+          🔥 {streak}d Streak
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default AchievementBadge;

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Task } from '../types';
+import AchievementBadge from './AchievementBadge';
 
 export interface TaskListProps {
   /** List of tasks to display. */
@@ -20,6 +21,23 @@ const TaskList: React.FC<TaskListProps> = ({ tasks }) => {
   const tasksToday = tasks.filter((task: Task) => task.timestamp >= startOfDay && task.timestamp <= endOfDay);
   const totalPointsToday = tasksToday.reduce((sum: number, task: Task) => sum + (task.points || 0), 0);
 
+  // Total points across all tasks for badge milestones
+  const totalPoints = tasks.reduce((sum: number, task: Task) => sum + (task.points || 0), 0);
+
+  // Calculate the current daily streak
+  const calculateStreak = (): number => {
+    if (tasks.length === 0) return 0;
+    const daySet = new Set(tasks.map((t) => t.timestamp.toDateString()));
+    const day = new Date();
+    let streak = 0;
+    while (daySet.has(day.toDateString())) {
+      streak += 1;
+      day.setDate(day.getDate() - 1);
+    }
+    return streak;
+  };
+  const streak = calculateStreak();
+
   return (
     <div className="w-full max-w-md mt-6 mx-auto space-y-4">
       <div className="bg-white/70 backdrop-blur-sm rounded-lg shadow-md p-4 flex justify-between items-center">
@@ -32,6 +50,7 @@ const TaskList: React.FC<TaskListProps> = ({ tasks }) => {
           <p className="text-2xl font-bold text-green-700">{totalPointsToday}</p>
         </div>
       </div>
+      <AchievementBadge totalPoints={totalPoints} streak={streak} />
       <ul className="space-y-2">
         {tasks
           .slice()


### PR DESCRIPTION
## Summary
- introduce `AchievementBadge` component to track point milestones and daily streaks
- show badges and streak below the task summary

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688896f8d3c88325a7cec0c653ee3eb8