### PR TITLE
Switch points to money

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,12 +51,12 @@ const App: React.FC = () => {
    * updating state. Note that the timestamp is always set to the
    * current date to reflect the time of completion.
    */
-  const handleAddTask = (name: string, points?: number) => {
+  const handleAddTask = (name: string, amount?: number) => {
     const newTask: Task = {
       id: generateId(),
       name,
       timestamp: new Date(),
-      points,
+      amount,
     };
     setTasks((prev: Task[]) => [...prev, newTask]);
   };

--- a/src/components/AchievementBadge.tsx
+++ b/src/components/AchievementBadge.tsx
@@ -1,29 +1,29 @@
 import React from 'react';
 
 export interface AchievementBadgeProps {
-  /** Total points accumulated across all tasks */
-  totalPoints: number;
+  /** Total amount accumulated across all tasks */
+  totalAmount: number;
   /** Number of consecutive days with at least one task */
   streak: number;
 }
 
 /**
- * Determine which badge label to show based on the total points earned.
+ * Determine which badge label to show based on the total money earned.
  * Returns null if no badge threshold has been reached.
  */
-function getBadgeLabel(points: number): string | null {
-  if (points >= 500) return 'Gold';
-  if (points >= 200) return 'Silver';
-  if (points >= 100) return 'Bronze';
+function getBadgeLabel(amount: number): string | null {
+  if (amount >= 500) return 'Gold';
+  if (amount >= 200) return 'Silver';
+  if (amount >= 100) return 'Bronze';
   return null;
 }
 
 /**
  * AchievementBadge shows a small visual indicator of a user's progress
- * in the form of a badge for point milestones and a streak counter.
+ * in the form of a badge for earning milestones and a streak counter.
  */
-const AchievementBadge: React.FC<AchievementBadgeProps> = ({ totalPoints, streak }) => {
-  const badge = getBadgeLabel(totalPoints);
+const AchievementBadge: React.FC<AchievementBadgeProps> = ({ totalAmount, streak }) => {
+  const badge = getBadgeLabel(totalAmount);
   return (
     <div className="flex space-x-2 mt-2">
       {badge && (

--- a/src/components/AddTask.tsx
+++ b/src/components/AddTask.tsx
@@ -5,28 +5,28 @@ export interface AddTaskProps {
    * Callback invoked when the user submits a new task.
    *
    * @param name The name of the completed task.
-   * @param points Optional points awarded for the task.
+   * @param amount Optional money awarded for the task.
    */
-  onAdd: (name: string, points?: number) => void;
+  onAdd: (name: string, amount?: number) => void;
 }
 
 /**
  * AddTask renders a button that opens a modal dialog for entering the
  * description of a completed task. The modal collects the task name
- * and optional points, then passes that data back to the parent via
+ * and optional amount, then passes that data back to the parent via
  * the onAdd callback.
- */
+*/
 const AddTask: React.FC<AddTaskProps> = ({ onAdd }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [taskName, setTaskName] = useState('');
-  const [points, setPoints] = useState<number | ''>('');
+  const [amount, setAmount] = useState<number | ''>('');
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (taskName.trim().length === 0) return;
-    onAdd(taskName.trim(), points === '' ? undefined : Number(points));
+    onAdd(taskName.trim(), amount === '' ? undefined : Number(amount));
     setTaskName('');
-    setPoints('');
+    setAmount('');
     setIsOpen(false);
   };
 
@@ -58,19 +58,20 @@ const AddTask: React.FC<AddTaskProps> = ({ onAdd }) => {
                 />
               </div>
               <div>
-                <label htmlFor="points" className="block text-sm font-medium text-gray-600 mb-1">
-                  Points (optional)
+                <label htmlFor="amount" className="block text-sm font-medium text-gray-600 mb-1">
+                  Amount Earned (optional)
                 </label>
                 <input
-                  id="points"
+                  id="amount"
                   type="number"
+                  step="0.01"
                   className="w-full border border-gray-300 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-green-400"
-                  value={points}
+                  value={amount}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                     const val = e.target.value;
-                    setPoints(val === '' ? '' : Number(val));
+                    setAmount(val === '' ? '' : Number(val));
                   }}
-                  placeholder="10"
+                  placeholder="10.00"
                 />
               </div>
               <div className="flex justify-end space-x-3 pt-2">

--- a/src/components/ProgressChart.tsx
+++ b/src/components/ProgressChart.tsx
@@ -8,7 +8,7 @@ export interface ProgressChartProps {
 }
 
 /**
- * ProgressChart renders a small bar chart showing the total points
+ * ProgressChart renders a small bar chart showing the total money
  * earned each day over the last week. It uses D3 for scales and axes
  * but is otherwise a self-contained React component.
  */
@@ -34,7 +34,7 @@ const ProgressChart: React.FC<ProgressChartProps> = ({ tasks }) => {
       const label = day.toLocaleDateString(undefined, { weekday: 'short' });
       const total = tasks
         .filter((t) => t.timestamp.toDateString() === day.toDateString())
-        .reduce((sum, t) => sum + (t.points || 0), 0);
+        .reduce((sum, t) => sum + (t.amount || 0), 0);
       return { label, total };
     });
 
@@ -82,7 +82,7 @@ const ProgressChart: React.FC<ProgressChartProps> = ({ tasks }) => {
   return (
     <div className="bg-white/70 backdrop-blur-sm rounded-lg shadow-md p-4 mt-6">
       <h2 className="text-lg font-semibold text-gray-700 mb-2">
-        Points Earned This Week
+        Money Earned This Week
       </h2>
       <svg ref={svgRef} className="w-full h-48" />
     </div>

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -9,9 +9,9 @@ export interface TaskListProps {
 
 /**
  * TaskList renders a summary of completed tasks, including the count of
- * tasks completed today and the total number of points earned. Each
- * task entry shows the name, completion time and points earned.
- */
+ * tasks completed today and the total amount of money earned. Each
+ * task entry shows the name, completion time and amount earned.
+*/
 const TaskList: React.FC<TaskListProps> = ({ tasks }) => {
   // Get today's date boundaries to compute tasks completed today
   const startOfDay = new Date();
@@ -19,10 +19,10 @@ const TaskList: React.FC<TaskListProps> = ({ tasks }) => {
   const endOfDay = new Date();
   endOfDay.setHours(23, 59, 59, 999);
   const tasksToday = tasks.filter((task: Task) => task.timestamp >= startOfDay && task.timestamp <= endOfDay);
-  const totalPointsToday = tasksToday.reduce((sum: number, task: Task) => sum + (task.points || 0), 0);
+  const totalAmountToday = tasksToday.reduce((sum: number, task: Task) => sum + (task.amount || 0), 0);
 
-  // Total points across all tasks for badge milestones
-  const totalPoints = tasks.reduce((sum: number, task: Task) => sum + (task.points || 0), 0);
+  // Total amount across all tasks for badge milestones
+  const totalAmount = tasks.reduce((sum: number, task: Task) => sum + (task.amount || 0), 0);
 
   // Calculate the current daily streak
   const calculateStreak = (): number => {
@@ -46,11 +46,13 @@ const TaskList: React.FC<TaskListProps> = ({ tasks }) => {
           <p className="text-2xl font-bold text-green-700">{tasksToday.length}</p>
         </div>
         <div>
-          <p className="text-lg font-semibold text-gray-700">Points</p>
-          <p className="text-2xl font-bold text-green-700">{totalPointsToday}</p>
+          <p className="text-lg font-semibold text-gray-700">Money Earned</p>
+          <p className="text-2xl font-bold text-green-700">
+            {totalAmountToday.toLocaleString(undefined, { style: 'currency', currency: 'USD' })}
+          </p>
         </div>
       </div>
-      <AchievementBadge totalPoints={totalPoints} streak={streak} />
+      <AchievementBadge totalAmount={totalAmount} streak={streak} />
       <ul className="space-y-2">
         {tasks
           .slice()
@@ -69,9 +71,9 @@ const TaskList: React.FC<TaskListProps> = ({ tasks }) => {
                   })}
                 </p>
               </div>
-              {task.points !== undefined && (
+              {task.amount !== undefined && (
                 <span className="bg-green-200 text-green-800 text-sm font-semibold px-2 py-1 rounded-full">
-                  +{task.points}
+                  💰{task.amount.toLocaleString(undefined, { style: 'currency', currency: 'USD' })}
                 </span>
               )}
             </li>

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,8 +2,8 @@
  * Defines the structure of a task item within the task reward application.
  *
  * Each task contains a unique identifier, a name describing the task,
- * a timestamp marking when it was completed, and an optional number
- * of points awarded for finishing the task. The id property is useful
+ * a timestamp marking when it was completed, and an optional amount
+ * of money awarded for finishing the task. The id property is useful
  * for efficiently rendering and updating list items in React.
  */
 export interface Task {
@@ -13,6 +13,6 @@ export interface Task {
   name: string;
   /** When the task was completed. Stored as a Date object for easy formatting. */
   timestamp: Date;
-  /** Optional points earned from completing the task. Defaults to 0 if omitted. */
-  points?: number;
+  /** Optional money earned from completing the task. Defaults to 0 if omitted. */
+  amount?: number;
 }


### PR DESCRIPTION
## Summary
- change points to money for tasks and history
- adjust UI labels and badge props

## Testing
- `npx tsc --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6888c2d0d258832592ea8b5932bf7700