### PR TITLE
Add difficulty selector for fixed points

### DIFF
--- a/src/components/AddTask.tsx
+++ b/src/components/AddTask.tsx
@@ -5,7 +5,7 @@ export interface AddTaskProps {
    * Callback invoked when the user submits a new task.
    *
    * @param name The name of the completed task.
-   * @param amount Optional money awarded for the task.
+   * @param amount Points awarded for the task based on difficulty.
    */
   onAdd: (name: string, amount?: number) => void;
 }
@@ -13,20 +13,21 @@ export interface AddTaskProps {
 /**
  * AddTask renders a button that opens a modal dialog for entering the
  * description of a completed task. The modal collects the task name
- * and optional amount, then passes that data back to the parent via
- * the onAdd callback.
+ * and difficulty level, then passes the appropriate point value back
+ * to the parent via the onAdd callback.
 */
 const AddTask: React.FC<AddTaskProps> = ({ onAdd }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [taskName, setTaskName] = useState('');
-  const [amount, setAmount] = useState<number | ''>('');
+  const [difficulty, setDifficulty] = useState<'easy' | 'medium' | 'hard'>('easy');
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (taskName.trim().length === 0) return;
-    onAdd(taskName.trim(), amount === '' ? undefined : Number(amount));
+    const points = difficulty === 'easy' ? 5 : difficulty === 'medium' ? 10 : 20;
+    onAdd(taskName.trim(), points);
     setTaskName('');
-    setAmount('');
+    setDifficulty('easy');
     setIsOpen(false);
   };
 
@@ -58,21 +59,19 @@ const AddTask: React.FC<AddTaskProps> = ({ onAdd }) => {
                 />
               </div>
               <div>
-                <label htmlFor="amount" className="block text-sm font-medium text-gray-600 mb-1">
-                  Amount Earned (optional)
+                <label htmlFor="difficulty" className="block text-sm font-medium text-gray-600 mb-1">
+                  Difficulty
                 </label>
-                <input
-                  id="amount"
-                  type="number"
-                  step="0.01"
+                <select
+                  id="difficulty"
                   className="w-full border border-gray-300 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-green-400"
-                  value={amount}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    const val = e.target.value;
-                    setAmount(val === '' ? '' : Number(val));
-                  }}
-                  placeholder="10.00"
-                />
+                  value={difficulty}
+                  onChange={(e) => setDifficulty(e.target.value as 'easy' | 'medium' | 'hard')}
+                >
+                  <option value="easy">Easy (5 pts)</option>
+                  <option value="medium">Medium (10 pts)</option>
+                  <option value="hard">Hard (20 pts)</option>
+                </select>
               </div>
               <div className="flex justify-end space-x-3 pt-2">
                 <button

--- a/src/components/ProgressChart.tsx
+++ b/src/components/ProgressChart.tsx
@@ -8,7 +8,7 @@ export interface ProgressChartProps {
 }
 
 /**
- * ProgressChart renders a small bar chart showing the total money
+ * ProgressChart renders a small bar chart showing the total points
  * earned each day over the last week. It uses D3 for scales and axes
  * but is otherwise a self-contained React component.
  */
@@ -82,7 +82,7 @@ const ProgressChart: React.FC<ProgressChartProps> = ({ tasks }) => {
   return (
     <div className="bg-white/70 backdrop-blur-sm rounded-lg shadow-md p-4 mt-6">
       <h2 className="text-lg font-semibold text-gray-700 mb-2">
-        Money Earned This Week
+        Points Earned This Week
       </h2>
       <svg ref={svgRef} className="w-full h-48" />
     </div>

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -9,8 +9,8 @@ export interface TaskListProps {
 
 /**
  * TaskList renders a summary of completed tasks, including the count of
- * tasks completed today and the total amount of money earned. Each
- * task entry shows the name, completion time and amount earned.
+ * tasks completed today and the total points earned. Each
+ * task entry shows the name, completion time and points awarded.
 */
 const TaskList: React.FC<TaskListProps> = ({ tasks }) => {
   // Get today's date boundaries to compute tasks completed today
@@ -46,10 +46,8 @@ const TaskList: React.FC<TaskListProps> = ({ tasks }) => {
           <p className="text-2xl font-bold text-green-700">{tasksToday.length}</p>
         </div>
         <div>
-          <p className="text-lg font-semibold text-gray-700">Money Earned</p>
-          <p className="text-2xl font-bold text-green-700">
-            {totalAmountToday.toLocaleString(undefined, { style: 'currency', currency: 'USD' })}
-          </p>
+          <p className="text-lg font-semibold text-gray-700">Points Earned</p>
+          <p className="text-2xl font-bold text-green-700">{totalAmountToday}</p>
         </div>
       </div>
       <AchievementBadge totalAmount={totalAmount} streak={streak} />
@@ -73,7 +71,7 @@ const TaskList: React.FC<TaskListProps> = ({ tasks }) => {
               </div>
               {task.amount !== undefined && (
                 <span className="bg-green-200 text-green-800 text-sm font-semibold px-2 py-1 rounded-full">
-                  💰{task.amount.toLocaleString(undefined, { style: 'currency', currency: 'USD' })}
+                  ⭐ {task.amount} pts
                 </span>
               )}
             </li>

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@
  *
  * Each task contains a unique identifier, a name describing the task,
  * a timestamp marking when it was completed, and an optional amount
- * of money awarded for finishing the task. The id property is useful
+ * of points awarded for finishing the task. The id property is useful
  * for efficiently rendering and updating list items in React.
  */
 export interface Task {
@@ -13,6 +13,6 @@ export interface Task {
   name: string;
   /** When the task was completed. Stored as a Date object for easy formatting. */
   timestamp: Date;
-  /** Optional money earned from completing the task. Defaults to 0 if omitted. */
+  /** Optional points earned from completing the task. Defaults to 0 if omitted. */
   amount?: number;
 }


### PR DESCRIPTION
## Summary
- replace manual amount input with a difficulty dropdown
- show total points earned instead of currency
- update progress chart and type docs for points

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6888c74a34cc83259d7ebf667075631d