### PR TITLE
Show previous tasks in collapsible list

### DIFF
--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Task } from '../types';
 import AchievementBadge from './AchievementBadge';
 
@@ -18,8 +18,14 @@ const TaskList: React.FC<TaskListProps> = ({ tasks }) => {
   startOfDay.setHours(0, 0, 0, 0);
   const endOfDay = new Date();
   endOfDay.setHours(23, 59, 59, 999);
-  const tasksToday = tasks.filter((task: Task) => task.timestamp >= startOfDay && task.timestamp <= endOfDay);
+  const tasksToday = tasks.filter(
+    (task: Task) => task.timestamp >= startOfDay && task.timestamp <= endOfDay,
+  );
   const totalPointsToday = tasksToday.reduce((sum: number, task: Task) => sum + (task.points || 0), 0);
+
+  // Tasks from previous days
+  const previousTasks = tasks.filter((task: Task) => task.timestamp < startOfDay);
+  const [showPrevious, setShowPrevious] = useState(false);
 
   // Total points across all tasks for badge milestones
   const totalPoints = tasks.reduce((sum: number, task: Task) => sum + (task.points || 0), 0);
@@ -52,7 +58,7 @@ const TaskList: React.FC<TaskListProps> = ({ tasks }) => {
       </div>
       <AchievementBadge totalPoints={totalPoints} streak={streak} />
       <ul className="space-y-2">
-        {tasks
+        {tasksToday
           .slice()
           .sort((a: Task, b: Task) => b.timestamp.getTime() - a.timestamp.getTime())
           .map((task: Task) => (
@@ -77,6 +83,59 @@ const TaskList: React.FC<TaskListProps> = ({ tasks }) => {
             </li>
           ))}
       </ul>
+
+      {previousTasks.length > 0 && (
+        <div className="mt-4">
+          <button
+            type="button"
+            onClick={() => setShowPrevious((prev) => !prev)}
+            className="w-full flex justify-between items-center bg-white/70 backdrop-blur-sm rounded-md px-4 py-2 shadow hover:shadow-md transition"
+          >
+            <span className="font-medium text-gray-700">Previous Tasks</span>
+            <svg
+              className={`w-4 h-4 transform transition-transform ${showPrevious ? 'rotate-180' : ''}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
+          <ul
+            className={`space-y-2 overflow-hidden transition-all duration-300 ${showPrevious ? 'max-h-screen mt-2' : 'max-h-0'}`}
+          >
+            {previousTasks
+              .slice()
+              .sort((a: Task, b: Task) => b.timestamp.getTime() - a.timestamp.getTime())
+              .map((task: Task) => (
+                <li
+                  key={task.id}
+                  className="bg-white/80 backdrop-blur-sm rounded-md p-3 shadow-sm flex justify-between items-center hover:shadow-md transition-shadow"
+                >
+                  <div>
+                    <p className="font-medium text-gray-800">{task.name}</p>
+                    <p className="text-xs text-gray-500">
+                      {task.timestamp.toLocaleDateString(undefined, {
+                        month: 'short',
+                        day: 'numeric',
+                      })}{' '}
+                      {task.timestamp.toLocaleTimeString(undefined, {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}
+                    </p>
+                  </div>
+                  {task.points !== undefined && (
+                    <span className="bg-green-200 text-green-800 text-sm font-semibold px-2 py-1 rounded-full">
+                      ⭐ {task.points} coins
+                    </span>
+                  )}
+                </li>
+              ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- filter today's tasks and keep older tasks separate
- hide older tasks under a collapsible "Previous Tasks" toggle
- style toggle with Tailwind and smooth transitions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6889c51b00588325b005bec5fec30e40